### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: Cargo Build & Test
 
-on:
-  push:
-  pull_request:
+on: {push, pull_request, workflow_dispatch}
 
 env: 
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
- Add the Cargo default CI flow
- Add a cache action
- Allow manual trigger for CI runs

Amusingly, the longest step on a cache hit is "run rustup to update the version".
I might follow up with getting rid of nightly from the matrix, for that reason.
