### PR TITLE
fix: empty results are falsy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -289,7 +289,7 @@ dependencies = [
 
 [[package]]
 name = "htmpl"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "ego-tree",
  "html5ever",

--- a/TODO.md
+++ b/TODO.md
@@ -7,6 +7,7 @@
         - Needs a redesign: attributes are key-value, not list-of-mappings.
         - Apply via selector: OK
     - [x] htmpl-if
+        - [ ] Test case for "empty row"
     - [ ] [Rust API guidelines](https://rust-lang.github.io/api-guidelines/)
     - [ ] `as` attribute
     - [ ] `insert` filters

--- a/src/lib.md
+++ b/src/lib.md
@@ -299,9 +299,10 @@ element will not be available outside of the `htmpl-if`.
 
 ### Truthiness
 
-Truthiness depends on the affinity of the type.
+- Null values are always false.
+- Queries which produce no rows are always false.
 
-Null values are always false. Beyond that, truthiness depends on the value's affinity:
+If a value is present, truthiness depends on the value's affinity:
 
 - Integer: 0 is falsy, all other values are truthy
 - String: the empty strings is falsy, all nonempty strings truthy

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -338,3 +338,14 @@ fn falsy() {
     "#,
     );
 }
+
+#[test_log::test]
+fn empty_is_falsy() {
+    let conn = make_test_db();
+    const TEMPLATE: &str = r#"
+        <htmpl-query name="q">SELECT name FROM users WHERE name = "odysseus";</htmpl-query>
+        <htmpl-if false="q(name)">No one is here</htmpl-if>
+        "#;
+    let result = evaluate_template(TEMPLATE, &conn).unwrap();
+    html_equal(result, "No one is here");
+}


### PR DESCRIPTION
Change the rules of truthiness and falsehood. Queries that return empty
results are no longer erroneous; they are merely falsy.

Is this a good idea? Maybe, maybe not.
